### PR TITLE
Correct healthcheck filename

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ logging:
 
 healthcheck:
   frequency: 15000 #milliseconds
-  filename: /tmp/case-processor-healthy
+  filename: /tmp/job-processor-healthy
 
 queueconfig:
   new-case-topic: event_new-case


### PR DESCRIPTION
# Motivation and Context
Healthchecks are failing because filename is wrong.

# What has changed
Fixed.

# How to test?
Don't.

# Links
Trello: https://trello.com/c/nOrXHmfn