### PR TITLE
Bump common entities version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.11.0-SNAPSHOT</version>
+      <version>4.12.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>


### PR DESCRIPTION
# Motivation and Context
Global permissions need to be handled differently from survey-specific permissions. For example, being able to see the list of SMS templates is not something survey specific. As such, it's hard for our UI to know what APIs are allowed to be called.

To solve this problem, by marking global permissions as global, we can filter those permissions out when the user is a super user on a specific survey, so it doesn't confuse the UI.

# What has changed
Added `global` flag to permissions. Filtered out the global permissions for survey specific super users. Denied any requests to use global permissions on specific surveys, because that's nonsense.

There's still some UI work to do to prevent people from attempting to put global permissions on surveys, but the backend will prevent it.

# How to test?
Try it out.

# Links
Trello: https://trello.com/c/DrxN8MHD