### PR TITLE
Updating log4j version to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,12 +56,12 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-rm-common-entity-model</artifactId>
-      <version>4.12.0-SNAPSHOT</version>
+      <version>4.12.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.4.0-SNAPSHOT</version>
+      <version>1.4.1-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There's a zero day exploit in log4j to execute code remotely. We don't use log4j in any of code but the spring-boot-starter has it as part of it's dependency tree so to be safe we're updating log4j to a new version before the next release.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Updated log4j version to 2.15.0
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run mvn clean install and run ATs for safe measure I guess
- After mvn clean install run ` mvn dependency:list | grep log4j` and check it's on 2.15.0
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/NsfNOlYt/3170-log4j-vulnerability-in-our-dependency-tree-from-sprint-boot-starter-upgrade-needed)
# Screenshots (if appropriate):
