### PR TITLE
Handle failed validation rows in more robust way

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/schedule/RowChunkValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/schedule/RowChunkValidator.java
@@ -30,9 +30,7 @@ public class RowChunkValidator {
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public boolean processChunk(Job job) {
-    boolean hadErrors = false;
-
+  public void processChunk(Job job) {
     JobTypeSettings jobTypeSettings =
         jobTypeHelper.getJobTypeSettings(job.getJobType(), job.getCollectionExercise());
 
@@ -68,7 +66,6 @@ public class RowChunkValidator {
             rowStatus = JobRowStatus.VALIDATED_ERROR;
             rowValidationErrors.add(
                 String.format("fieldToUpdate column %s does not exist", fieldToUpdate));
-            hadErrors = true;
             columnValidators = new ColumnValidator[0];
           }
         }
@@ -80,7 +77,6 @@ public class RowChunkValidator {
         if (columnValidationErrors.isPresent()) {
           rowStatus = JobRowStatus.VALIDATED_ERROR;
           rowValidationErrors.add(columnValidationErrors.get());
-          hadErrors = true;
         }
       }
 
@@ -95,7 +91,5 @@ public class RowChunkValidator {
 
     jobRowRepository.saveAll(jobRows);
     jobRepository.saveAndFlush(job);
-
-    return hadErrors;
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/schedule/StagedJobValidator.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/schedule/StagedJobValidator.java
@@ -32,12 +32,14 @@ public class StagedJobValidator {
     List<Job> jobs = jobRepository.findByJobStatus(JobStatus.VALIDATION_IN_PROGRESS);
 
     for (Job job : jobs) {
-      JobStatus jobStatus = JobStatus.VALIDATED_OK;
 
       while (jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.STAGED)) {
-        if (rowChunkValidator.processChunk(job)) {
-          jobStatus = JobStatus.VALIDATED_WITH_ERRORS;
-        }
+        rowChunkValidator.processChunk(job);
+      }
+
+      JobStatus jobStatus = JobStatus.VALIDATED_OK;
+      if (jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_ERROR)) {
+        jobStatus = JobStatus.VALIDATED_WITH_ERRORS;
       }
 
       job.setJobStatus(jobStatus);

--- a/src/test/java/uk/gov/ons/ssdc/jobprocessor/schedule/StagedJobValidatorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/jobprocessor/schedule/StagedJobValidatorTest.java
@@ -35,7 +35,8 @@ class StagedJobValidatorTest {
     when(jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.STAGED))
         .thenReturn(true)
         .thenReturn(false);
-    when(rowChunkValidator.processChunk(job)).thenReturn(false);
+    when(jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_ERROR))
+        .thenReturn(false);
 
     // When
     underTest.processStagedJobs();
@@ -60,7 +61,8 @@ class StagedJobValidatorTest {
         .thenReturn(true)
         .thenReturn(true)
         .thenReturn(false);
-    when(rowChunkValidator.processChunk(job)).thenReturn(false);
+    when(jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_ERROR))
+        .thenReturn(false);
 
     // When
     underTest.processStagedJobs();
@@ -83,7 +85,8 @@ class StagedJobValidatorTest {
     when(jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.STAGED))
         .thenReturn(true)
         .thenReturn(false);
-    when(rowChunkValidator.processChunk(job)).thenReturn(true);
+    when(jobRowRepository.existsByJobAndJobRowStatus(job, JobRowStatus.VALIDATED_ERROR))
+        .thenReturn(true);
 
     // When
     underTest.processStagedJobs();


### PR DESCRIPTION
# Motivation and Context
It was possible that a large CSV file being processed, should the Job Processor crash or be restarted during processing, would end up mis-reporting a job as having no validation errors, when in fact it did, due to that check taking place in memory rather than using the database.

# What has changed
The final check for any rows which failed validation is done in the database, rather than in memory.

# How to test?
Load a big CSV file with an error at the beginning. Once it begins validating, shut down the job processor. When you restart the job processor, you should see that it correctly indicates the job was validated with errors, not validated OK.

# Links
Trello: https://trello.com/c/lGyq9Y0v