### PR TITLE
3277 - Add PMD and errorprone checks

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,1 +1,10 @@
---add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - IMAGE_NAME="$DOCKER_GCP_LOCATION/ssdc-rm-job-processor"
 
 before_install:
-  - mvn fmt:check
+  - mvn fmt:check pmd:check
   - docker login -u "${DOCKER_GCP_USERNAME}" -p "${DOCKER_GCP_PASSWORD}" https://europe-west2-docker.pkg.dev;
   - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
   - docker network create ssdcrmdockerdev_default

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ format:
 format-check:
 	mvn fmt:check
 
+check:
+	mvn fmt:check pmd:check
+
 test:
 	mvn clean verify jacoco:report
 

--- a/exclude-pmd.properties
+++ b/exclude-pmd.properties
@@ -1,0 +1,4 @@
+# TODO: as a team, define our own custom PMD checker so that we don't have to keep adding piecemeal
+#       to this file
+
+uk.gov.ons.ssdc.jobprocessor.jobtype.processors.JobTypeProcessor=AbstractClassWithoutAbstractMethod, MethodReturnsInternalArray

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,29 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.16.0</version>
+        <configuration>
+          <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
+          <failurePriority>3</failurePriority>
+          <failOnViolation>true</failOnViolation>
+          <verbose>true</verbose>
+          <rulesets>
+            <ruleset>/category/java/bestpractices.xml</ruleset>
+            <ruleset>/category/java/security.xml</ruleset>
+          </rulesets>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <executions>
           <execution>
@@ -268,7 +291,24 @@
         <configuration>
           <source>17</source>
           <target>17</target>
-        </configuration>
+          <encoding>UTF-8</encoding>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.11.0</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.22</version>
+            </path>
+          </annotationProcessorPaths>
+      </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -305,7 +305,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.22</version>
+              <version>1.18.20</version>
             </path>
           </annotationProcessorPaths>
       </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,7 @@
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
           <verbose>true</verbose>
+          <linkXRef>false</linkXRef>
           <rulesets>
             <ruleset>/category/java/bestpractices.xml</ruleset>
             <ruleset>/category/java/security.xml</ruleset>

--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/config/AppConfig.java
@@ -48,7 +48,7 @@ public class AppConfig {
 
   @PostConstruct
   public void init() {
-    if (loggingProfile.equals("STRUCTURED")) {
+    if ("STRUCTURED".equals(loggingProfile)) {
       LoggingConfigs.setCurrent(LoggingConfigs.getCurrent().useJson());
     }
 

--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/jobtype/processors/BulkUpdateSampleTypeProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/jobtype/processors/BulkUpdateSampleTypeProcessor.java
@@ -28,6 +28,7 @@ public class BulkUpdateSampleTypeProcessor extends JobTypeProcessor {
     setFileViewProgressPermission(UserGroupAuthorisedActivityType.VIEW_BULK_UPDATE_SAMPLE_PROGRESS);
   }
 
+  @Override
   public ColumnValidator[] getColumnValidators(JobRow jobRow)
       throws ValidatorFieldNotFoundException {
     String fieldToUpdate = jobRow.getRowData().get("fieldToUpdate");

--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/jobtype/processors/BulkUpdateSensitiveSampleTypeProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/jobtype/processors/BulkUpdateSensitiveSampleTypeProcessor.java
@@ -30,6 +30,7 @@ public class BulkUpdateSensitiveSampleTypeProcessor extends JobTypeProcessor {
         UserGroupAuthorisedActivityType.VIEW_BULK_UPDATE_SAMPLE_SENSITIVE_PROGRESS);
   }
 
+  @Override
   public ColumnValidator[] getColumnValidators(JobRow jobRow)
       throws ValidatorFieldNotFoundException {
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can introduce PMD and ErrorProne code analysis/compile tools to our Java apps. Drawing from [this spike branch](https://github.com/ONSdigital/ssdc-rm-response-operations/pull/78/files) and adding some additional bits.

I’ve put a `<failurePriority>`  of `3` for PMD (scale of 1 - 5, with `1` being 'severe'), so it will fail on anything over a medium level severity. Anything below this level will output as a warning. I’ve set it at a level that seems sensible, but it’s debatable!

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Add PMD ignore file for code to be ignored for now, but to investigate later 
* Fix some errors & warnings from PMD
* Add `check` target to Makefile
* Update Travis checks

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* If you want to see some of the PMD failures, comment out the lines in `exclude-pmd.propeties` file.
* Check to see the tools pick up the issues as expected.
* Run ATs, should still pass.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Y4aAAwHb/3277-java-checks-8