### PR TITLE
update Docker to eclipse alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-ARG JAR_FILE=ssdc-rm-job-processor*.jar
 CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN addgroup --gid 1000 jobprocessor && \
     adduser --system --uid 1000 jobprocessor jobprocessor
 USER jobprocessor
 
-COPY target/$JAR_FILE /opt/ssdc-rm-job-processor.jar
+COPY target/ssdc-rm-job-processor*.jar /opt/ssdc-rm-job-processor.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-ARG JAR_FIL=ssdc-rm-job-processo*.jar
+ARG JAR_FILE=ssdc-rm-job-processor*.jar
 CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN addgroup --gid 1000 jobprocessor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM eclipse-temurin:17-jdk-alpine
 
-CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
+CMD ["java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
+
 COPY healthcheck.sh /opt/healthcheck.sh
 RUN addgroup --gid 1000 jobprocessor && \
     adduser --system --uid 1000 jobprocessor jobprocessor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,10 @@
-FROM openjdk:17-slim
-CMD ["/usr/local/openjdk-17/bin/java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
+FROM eclipse-temurin:17-jdk-alpine
 
+ARG JAR_FIL=ssdc-rm-job-processo*.jar
+CMD ["/opt/java/openjdk/bin/java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
 COPY healthcheck.sh /opt/healthcheck.sh
-
-RUN groupadd --gid 999 jobprocessor && \
-    useradd --create-home --system --uid 999 --gid jobprocessor jobprocessor
-
-RUN apt-get update && \
-apt-get -yq install curl && \
-apt-get -yq clean && \
-rm -rf /var/lib/apt/lists/*
-
+RUN addgroup --gid 1000 jobprocessor && \
+    adduser --system --uid 1000 jobprocessor jobprocessor
 USER jobprocessor
 
-ARG JAR_FILE=ssdc-rm-job-processor*.jar
 COPY target/$JAR_FILE /opt/ssdc-rm-job-processor.jar


### PR DESCRIPTION
# Motivation and Context
OpenJDK support not great, use this eclipse alpine instead

# What has changed
Base image and healthchecks, user etc

# How to test?
Should all work with ATs etc with zero regression

# Links
https://trello.com/c/EK2yClBJ/40-migrate-java-base-docker-image-5
