### PR TITLE
delete jobrows for cancelled jobs

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/repository/JobRowRepository.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/repository/JobRowRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 import uk.gov.ons.ssdc.common.model.entity.Job;
 import uk.gov.ons.ssdc.common.model.entity.JobRow;
 import uk.gov.ons.ssdc.common.model.entity.JobRowStatus;
+import uk.gov.ons.ssdc.common.model.entity.JobStatus;
 
 public interface JobRowRepository extends JpaRepository<JobRow, UUID> {
   boolean existsByJobAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
@@ -27,4 +28,6 @@ public interface JobRowRepository extends JpaRepository<JobRow, UUID> {
   void deleteByJob(@Param("job") Job job);
 
   List<JobRow> findTop500ByJobAndJobRowStatus(Job job, JobRowStatus jobRowStatus);
+
+  List<JobRow> findTop500ByJob_JobStatus(JobStatus jobStatus);
 }

--- a/src/main/java/uk/gov/ons/ssdc/jobprocessor/schedule/ValidatedJobProcessor.java
+++ b/src/main/java/uk/gov/ons/ssdc/jobprocessor/schedule/ValidatedJobProcessor.java
@@ -5,6 +5,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.ssdc.common.model.entity.Job;
+import uk.gov.ons.ssdc.common.model.entity.JobRow;
 import uk.gov.ons.ssdc.common.model.entity.JobRowStatus;
 import uk.gov.ons.ssdc.common.model.entity.JobStatus;
 import uk.gov.ons.ssdc.jobprocessor.repository.JobRepository;
@@ -12,6 +13,7 @@ import uk.gov.ons.ssdc.jobprocessor.repository.JobRowRepository;
 
 @Component
 public class ValidatedJobProcessor {
+
   private final JobRepository jobRepository;
   private final JobRowRepository jobRowRepository;
   private final RowChunkProcessor rowChunkProcessor;
@@ -40,5 +42,12 @@ public class ValidatedJobProcessor {
 
       jobRowRepository.deleteByJobAndJobRowStatus(job, JobRowStatus.PROCESSED);
     }
+  }
+
+  @Scheduled(fixedDelayString = "1000")
+  @Transactional
+  public void removeCancelledJobsRows() {
+    List<JobRow> jobRows = jobRowRepository.findTop500ByJob_JobStatus(JobStatus.CANCELLED);
+    jobRowRepository.deleteAll(jobRows);
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,8 +5,8 @@ info:
 
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:6432/postgres?readOnly=true
-    username: postgres
+    url: jdbc:postgresql://localhost:6432/rm
+    username: appuser
     password: postgres
     driverClassName: org.postgresql.Driver
     hikari:

--- a/src/test/java/uk/gov/ons/ssdc/jobprocessor/schedule/ValidatedJobProcessorTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/jobprocessor/schedule/ValidatedJobProcessorTest.java
@@ -15,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.ons.ssdc.common.model.entity.Job;
+import uk.gov.ons.ssdc.common.model.entity.JobRow;
 import uk.gov.ons.ssdc.common.model.entity.JobRowStatus;
 import uk.gov.ons.ssdc.common.model.entity.JobStatus;
 import uk.gov.ons.ssdc.jobprocessor.repository.JobRepository;
@@ -97,5 +98,19 @@ class ValidatedJobProcessorTest {
     verify(jobRepository, times(3)).save(any(Job.class));
     verify(jobRowRepository, times(3))
         .deleteByJobAndJobRowStatus(any(Job.class), eq(JobRowStatus.PROCESSED));
+  }
+
+  @Test
+  void removeCancelledJobRow() {
+
+    // Given
+    List<JobRow> jobRows = List.of(new JobRow());
+    when(jobRowRepository.findTop500ByJob_JobStatus(JobStatus.CANCELLED)).thenReturn(jobRows);
+
+    // When
+    underTest.removeCancelledJobsRows();
+
+    // Then
+    verify(jobRowRepository).deleteAll(jobRows);
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:16445/postgres
+    url: jdbc:postgresql://localhost:6432/rm
 
   cloud:
     gcp:


### PR DESCRIPTION
# Motivation and Context
When a Job is cancelled any JobRows related to it remain in the database rather than being deleted, causing them. to. build up over time.

# What has changed
Scheduled task to delete any job rows of jobs which have been cancelled

# How to test?
Bring up your dev env and stop JobProcessor
Add some dummy cancelled jobs to the DB and some job rows to go with them
bring up the new version of the job processor
Check that the job rows are gone for the cancelled jobs

