### PR TITLE
Sdcsrm 1570 updgrade to java21

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -47,10 +47,10 @@ jobs:
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jre-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 CMD ["java", "-jar", "/opt/ssdc-rm-job-processor.jar"]
 

--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ install-no-test:
 	CONTAINER_CLI=$(DOCKER) mvn clean install -Dmaven.test.skip=true -Dexec.skip=true -Djacoco.skip=true
 
 format:
-	mvn fmt:format
+	mvn spotless:apply
 
 format-check:
-	mvn fmt:check
+	mvn spotless:check
 
 check:
-	mvn fmt:check pmd:check
+	mvn spotless:check pmd:check
 
 test:
 	CONTAINER_CLI=$(DOCKER) mvn clean verify jacoco:report

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
   </parent>
 
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <java.version>21</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <container.cli>docker</container.cli>
   </properties>
 
@@ -286,14 +287,22 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.13</version>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.43.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.22.0</version> <!-- Java 21 compatible -->
+            </googleJavaFormat>
+          </java>
+        </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>format</goal>
+              <goal>check</goal>
             </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>
@@ -340,8 +349,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
@@ -356,7 +365,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.20</version>
+              <version>1.18.30</version>
             </path>
           </annotationProcessorPaths>
       </configuration>


### PR DESCRIPTION
# Motivation and Context
Upgrade to Java 21

# What has changed
- Updated the pom file to use spotless instead of fmt and to parameterize the Java version so that it only has to be set once
- Updated Docker file to pull the Java 21 image
- Updated Git Actions
- Updated the Makefile

# How to test?
Install Java 21 locally by running the dev-tools script (currently in PR)
All tests should pass and the image should build with no issues

# Links
[SDCSRM-1570](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570)

[SDCSRM-1570]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ